### PR TITLE
Use standard `POD_LABEL` rather than rolling your own

### DIFF
--- a/src/com/lilly/cirrus/jenkinsdsl/core/OpenshiftPodTemplate.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/core/OpenshiftPodTemplate.groovy
@@ -2,12 +2,6 @@ package com.lilly.cirrus.jenkinsdsl.core
 
 class OpenshiftPodTemplate extends PodTemplate {
 
-  @Override
-  String getLabel() {
-    if(!this.@label) this.@label = "oc-dsl-${UUID.randomUUID().toString()}"
-    return this.@label
-  }
-
   String getImagePullSecretYaml() {
     if (!this.@imagePullSecrets) return ''
     StringBuilder builder = new StringBuilder()

--- a/src/com/lilly/cirrus/jenkinsdsl/core/PodTemplate.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/core/PodTemplate.groovy
@@ -11,7 +11,6 @@ abstract class PodTemplate implements Serializable {
   static final boolean CONTAINER_TTY_ENABLED = true
   static final String CONTAINER_COMMAND = "cat"
 
-  protected String label
   protected String nameSpace
   protected String serviceAccount
   protected List<String> imagePullSecrets = []
@@ -65,16 +64,14 @@ abstract class PodTemplate implements Serializable {
     return spec
   }
 
-  abstract String getLabel()
   abstract protected String getPodSpec()
 
   def execute(def jenkins, Closure<?> closure) {
     if (!this.containers) throw new CirrusPipelineException('The pod is missing containers to run')
 
-    def label = this.getLabel()
     run(jenkins) {
-      podTemplate(label: label, namespace: this.nameSpace, yaml: this.getPodSpec()) {
-        node(label) {
+      podTemplate(namespace: this.nameSpace, yaml: this.getPodSpec()) {
+        node(POD_LABEL) {
           run jenkins, closure
         }
       }

--- a/test/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClientSpec.groovy
+++ b/test/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClientSpec.groovy
@@ -7,7 +7,7 @@ import com.lilly.cirrus.jenkinsdsl.core.CirrusPipelineException
 import com.lilly.cirrus.jenkinsdsl.sim.SimFactory
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 
-class OpenShiftClientSpec extends CirrusDSLSpec {
+class OpenshiftClientSpec extends CirrusDSLSpec {
   String getTestString(int length) {
     StringBuilder builder = new StringBuilder()
     for (int i = 0; i < length; ++i) {


### PR DESCRIPTION
# Summary

As of https://github.com/jenkinsci/kubernetes-plugin/pull/539 you should not need to explicitly come up with a pod label.

# Submitter's Pledge

Reviewers, I have verified the following to the best of my knowledge:

- [ ] I have added unit test cases for the changes where applicable.
- [ ] I have updated `CHANGELOG.md` with the new target version (or with the `Unreleased` tag) and updated the version comparison url in the file.
- [ ] I have updated documentation in `README.md` at the repo root and all of the applicable `README.md` files under `docs/**` along with necessary version change for code samples in those docs where applicable.
- [ ] I have read and fully understand the process for submitting a pull request to the codebase.

# Review Recommendation

Nothing specific; do changes of this kind get test coverage?
