### PR TITLE
Use the standard trick for `BuildAbortionStage`

### DIFF
--- a/src/com/lilly/cirrus/jenkinsdsl/core/BuildAbortionStage.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/core/BuildAbortionStage.groovy
@@ -14,19 +14,11 @@ class BuildAbortionStage extends Stage {
     withJenkins {
       echo "Checking for previous running builds to abort..."
 
-      def buildnum = env.BUILD_NUMBER.toInteger()
-      def job = currentBuild?.rawBuild?.parent
-
-      if (job && job.builds) {
-        for (build in job.builds) {
-          int buildId = build.getNumber()
-          if (!build.isBuilding()) { continue }
-          if (buildnum == build.getNumber().toInteger()) { continue }
-
-          echo ">> Aborting build #${build.getNumber()}"
-          build.doKill()
-        }
+      def buildNumber = BUILD_NUMBER as int
+      if (buildNumber > 1) {
+        milestone(buildNumber - 1)
       }
+      milestone(buildNumber)
 
       echo "Check for previous running builds complete. Proceeding to next stage, if any."
     }


### PR DESCRIPTION
# Summary

Avoids using non-sandbox-friendly methods to abort previous builds, using the standard workaround for JENKINS-43353. (Requires the `pipeline-milestone-step` plugin.) https://github.com/jenkinsci/workflow-job-plugin/pull/200 would be nicer.

# Submitter's Pledge

Reviewers, I have verified the following to the best of my knowledge:

- [ ] I have added unit test cases for the changes where applicable.
- [ ] I have updated `CHANGELOG.md` with the new target version (or with the `Unreleased` tag) and updated the version comparison url in the file.
- [ ] I have updated documentation in `README.md` at the repo root and all of the applicable `README.md` files under `docs/**` along with necessary version change for code samples in those docs where applicable.
- [ ] I have read and fully understand the process for submitting a pull request to the codebase.

# Review Recommendation

Not sure whether this is tested realistically.
