### PR TITLE
fix: Use registry pull secret when building images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - GitHub Actions Workflow Creation. 
 - Updated dependenices resolving security problems. 
 
+### Fixed
+- Use pull secret when creating Docker images in OpenShift BuildConfigs
+
 ## [1.0.0]
 ### Created
 - Initial release of JenkinsDSL core.
 
-[1.0.1]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/releases/v1.0.1...v1.0.0
+[1.0.1]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/releases/v1.0.0
 

--- a/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
@@ -142,7 +142,8 @@ class OpenshiftClient implements Serializable {
         "strategy": {
           "type": "Docker",
           "dockerStrategy": {
-            "noCache": true
+            "noCache": true,
+            "pullSecret": "${registrySecretName}"
           }
         }
       }


### PR DESCRIPTION
# Summary

Updates `getBuildConfig` in the OpenShift client to use the registry
secret to pull the base Docker image.

When OpenShift is used to create new Docker images, a "BuildConfig" is
created. This build config provides OpensShift with instructions on how
to build the Docker image. The current build config was using a secret
to push the build image into a registry, but it was not using this
secret when pulling the base Docker image. This means that it only
worked for base images in registries that allow anonymous access. This
commit updates the BuildConfig to use the registry secret when pulling
the image.

# Submitter's Pledge

Reviewers, I have verified the following to the best of my knowledge:

- [x] I have added unit test cases for the changes where applicable.
- [x] I have updated `CHANGELOG.md` with the new target version (or with the `Unreleased` tag) and updated the version comparison url in the file.
- [x] I have updated documentation in `README.md` at the repo root and all of the applicable `README.md` files under `docs/**` along with necessary version change for code samples in those docs where applicable.
- [x] I have read and fully understand the process for submitting a pull request to the codebase.

