### PR TITLE
Fix misformatted BuildConfig pull secret.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2]
+
+### Added
+- Use Docker image cache when making OpenShift BuildConfigs
+
+### Fixed
+- Fix formatting of OpenShift BuildConfig pull secret
+
 ## [1.0.1]
+
 ### Created
 - `SECURITY.md` file creation.
 - GitHub Actions Workflow Creation. 
@@ -14,9 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use pull secret when creating Docker images in OpenShift BuildConfigs
 
 ## [1.0.0]
+
 ### Created
 - Initial release of JenkinsDSL core.
 
+[1.0.2]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/EliLillyCo/CIRR_JenkinsPipelineLibraries/releases/v1.0.0
 

--- a/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
@@ -143,7 +143,9 @@ class OpenshiftClient implements Serializable {
           "type": "Docker",
           "dockerStrategy": {
             "noCache": true,
-            "pullSecret": "${registrySecretName}"
+            "pullSecret": {
+              "name": "${registrySecretName}"
+            }
           }
         }
       }

--- a/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
+++ b/src/com/lilly/cirrus/jenkinsdsl/openshift/OpenshiftClient.groovy
@@ -142,7 +142,6 @@ class OpenshiftClient implements Serializable {
         "strategy": {
           "type": "Docker",
           "dockerStrategy": {
-            "noCache": true,
             "pullSecret": {
               "name": "${registrySecretName}"
             }


### PR DESCRIPTION
# Summary

- Use Docker image cache when making OpenShift BuildConfigs
- Fix formatting of OpenShift BuildConfig pull secret

# Submitter's Pledge

Reviewers, I have verified the following to the best of my knowledge:

- [x] I have added unit test cases for the changes where applicable.
- [x] I have updated `CHANGELOG.md` with the new target version (or with the `Unreleased` tag) and updated the version comparison url in the file.
- [x] I have updated documentation in `README.md` at the repo root and all of the applicable `README.md` files under `docs/**` along with necessary version change for code samples in those docs where applicable.
- [x] I have read and fully understand the process for submitting a pull request to the codebase.
